### PR TITLE
Fix webpack config

### DIFF
--- a/webpack.config.babel.js
+++ b/webpack.config.babel.js
@@ -18,13 +18,12 @@ export default {
         libraryTarget: 'umd'
     },
     target: 'electron',
-    debug: false,
     module: {
         loaders: [
             {
                 test: /\.js$/,
                 exclude: /node_modules/,
-                loader: 'babel',
+                loader: 'babel-loader',
                 query: {
                     cacheDirectory: true
                 }
@@ -37,7 +36,7 @@ export default {
     },
     plugins: [
         new webpack.IgnorePlugin(/node_modules/),
-        new webpack.optimize.OccurenceOrderPlugin(),
+        new webpack.optimize.OccurrenceOrderPlugin(),
         new webpack.optimize.DedupePlugin(),
         new webpack.optimize.UglifyJsPlugin({
             compress: { warnings: false },


### PR DESCRIPTION
1.
TypeError: _webpack2.default.optimize.OccurenceOrderPlugin is not a constructor

2.
Invalid configuration object. Webpack has been initialised using a configuration object that does not match the API schema.
 - configuration has an unknown property 'debug'.

3.
BREAKING CHANGE: It's no longer allowed to omit the '-loader' suffix when using loaders.
                 You need to specify 'babel-loader' instead of 'babel'.