### PR TITLE
Added definitions for node-machine-id

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,7 @@
   "name": "node-machine-id",
   "version": "1.1.4",
   "main": "./dist/index.js",
+  "types": "./types/index.d.ts",
   "description": "Unique machine (desktop) id (no admin privileges required).",
   "author": "Aleksandr Komlev",
   "license": "MIT",

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,0 +1,17 @@
+﻿/**
+ * Module based on OS native UUID/GUID which used for internal needs.
+ */
+declare module 'node-machine-id' {
+
+    /**
+     * This function gets the OS native UUID/GUID synchronously, hashed by default.
+     * @param {boolean} [original=false] - If true return original value of machine id, otherwise return hashed value (sha - 256)
+     */
+    function machineIdSync(original?: boolean): string;
+
+    /**
+     * This function gets the OS native UUID/GUID asynchronously (recommended), hashed by default.
+     * @param {boolean} [original=false] - If true return original value of machine id, otherwise return hashed value (sha - 256)
+     */
+    function machineId(original?: boolean): Promise<string>;
+}


### PR DESCRIPTION
Would be a nice addition and was also requested in #12.

I'm no expert for typings though.