### PR TITLE
Complatibility with SMBIOS-disabled FreeBSD

### DIFF
--- a/index.js
+++ b/index.js
@@ -13,7 +13,7 @@ let {platform}: Object = process,
             'QUERY HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography ' +
             '/v MachineGuid',
         linux: '( cat /var/lib/dbus/machine-id /etc/machine-id 2> /dev/null || hostname ) | head -n 1 || :',
-        freebsd: 'kenv -q smbios.system.uuid'
+        freebsd: 'kenv -q smbios.system.uuid || sysctl -n kern.hostuuid'
     };
 
 function isWindowsProcessMixedOrNativeArchitecture(): string {


### PR DESCRIPTION
Added alternative command for retrieving system UUID on FreeBSD.