### PR TITLE
Specify the full path to ioreg rather than relying on PATH being correct

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ let {platform}: Object = process,
         mixed: '%windir%\\sysnative\\cmd.exe /c %windir%\\System32'
     },
     guid: Object = {
-        darwin: 'ioreg -rd1 -c IOPlatformExpertDevice',
+        darwin: '/usr/sbin/ioreg -rd1 -c IOPlatformExpertDevice',
         win32: `${win32RegBinPath[isWindowsProcessMixedOrNativeArchitecture()]}\\REG.exe ` +
             'QUERY HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Cryptography ' +
             '/v MachineGuid',


### PR DESCRIPTION
## What
Specify the full path to the `ioreg` command on macOS so node-machine-id works properly regardless of the $PATH it's being run with.

## Why
I just spent a few days chasing down a problem with the [homebridge-ring](https://github.com/dgreif/ring/) project that ultimately was caused by the fact that I was running without `/usr/sbin` in my `$PATH`.

I fixed my problem by fixing my path, but it seems prudent to make this change to avoid problems for anyone else who happens to accidentally have a wonky environment.

## Risks
Low; `ioreg` is part of Apple's I/O Kit and seems unlikely to move around in the future.