### PR TITLE
Catch exceptions in exec callback to ensure Promise is rejected

### DIFF
--- a/index.js
+++ b/index.js
@@ -68,13 +68,19 @@ export function machineIdSync(original: boolean): string {
 export function machineId(original: boolean): Promise<string> {
     return new Promise((resolve: Function, reject: Function): Object => {
         return exec(guid[platform], {}, (err: any, stdout: any, stderr: any) => {
-            if (err) {
-                return reject(
-                    new Error(`Error while obtaining machine id: ${err.stack}`)
-                );
+            // This is executing in a callback, so any Exceptions thrown will
+            // not reject the promise
+            try {
+                if (err) {
+                    return reject(
+                        new Error(`Error while obtaining machine id: ${err.stack}`)
+                    );
+                }
+                let id: string = expose(stdout.toString());
+                return resolve(original ? id : hash(id));
+            } catch (exception) {
+                return reject(exception);
             }
-            let id: string = expose(stdout.toString());
-            return resolve(original ? id : hash(id));
         });
     });
 }


### PR DESCRIPTION
### What
Adds try-catch block to exec callback for machineId()

### Why
A Promise has an implicit try-catch reject logic. However, the callback from `exec` is not handled by this implicit try-catch. Thus any exceptions thrown in `expose()` will not be caught and the promise will not be rejected.

I noticed this when some of my users had a 
`TypeError: Cannot read property 'replace' of undefined`
error on sentry

### Risk
Low: simple try catch block, does not change original resolve, reject behavior